### PR TITLE
feat: limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See [SETUP.md](./docs/SETUP.md), [CONFIG.md](./docs/CONFIG.md).
 ## API
  
 - [`promise`](#promise)
+- [`limit`](#limit)
 - [`later`](#later)
  
 ### `promise`
@@ -112,6 +113,20 @@ class AsyncQueue<T> {
   }
 }
 ```
+
+### `limit`
+
+```ts
+limit<T>(promise: Promise<T>, ms: number): Promise<T>
+limit<T>(promise: Promise<T>, deadline: Date): Promise<T>
+limit<T>(promise: Promise<T>, ctx: IContext): Promise<T>
+```
+
+`limit` awaits an input promise, but rejects it automatically if it has not completed by a timeout determined by any of the following:
+
+- A relative timeout in milliseconds
+- An absolute `Date` deadline
+- A cancelable context
 
 ### `later`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@
 
 export { later } from './later';
 export * from './promise';
+export { limit } from './limit';

--- a/src/limit.ts
+++ b/src/limit.ts
@@ -1,0 +1,130 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+import { CancelFunc, IContext } from '@sabl/context';
+import { FnReject } from './promise';
+
+function timeoutError() {
+  return new Error('Promise canceled due to timeout');
+}
+
+/**
+ * Await promise `p`, but automatically reject it if `ctx`
+ * is canceled before `p` resolves.
+ */
+export async function limit<T>(p: Promise<T>, ctx: IContext): Promise<T>;
+
+/**
+ * Await promise `p`, but automatically reject it if it
+ * has not resolved by `deadline`
+ */
+export async function limit<T>(p: Promise<T>, deadline: Date): Promise<T>;
+
+/**
+ * Await promise `p`, but automatically reject it if it
+ * has not resolved after `ms` milliseconds
+ */
+export async function limit<T>(p: Promise<T>, ms: number): Promise<T>;
+
+export async function limit<T>(
+  p: Promise<T>,
+  limiter: number | Date | IContext
+): Promise<T> {
+  let ms: number;
+  if (typeof limiter === 'number') {
+    ms = limiter;
+  } else if (limiter instanceof Date) {
+    ms = +limiter - +new Date();
+  } else {
+    // Context
+    return limitContext(p, limiter);
+  }
+
+  if (ms <= 0) {
+    return Promise.reject(timeoutError());
+  }
+
+  let rejected = false;
+
+  const timeout: {
+    token?: NodeJS.Timeout;
+    reject?: FnReject;
+  } = {};
+
+  const clearAndCancel = () => {
+    clearTimeout(timeout.token);
+    rejected = true;
+    timeout.reject!(timeoutError());
+  };
+
+  timeout.token = setTimeout(clearAndCancel, ms);
+
+  return new Promise<T>((resolve, reject) => {
+    timeout.reject = reject;
+    p.finally(() => {
+      clearTimeout(timeout.token);
+    })
+      .then((value) => {
+        if (rejected) {
+          // Already rejected by timeout
+          return;
+        }
+        resolve(value);
+      })
+      .catch((reason) => {
+        if (rejected) {
+          // Already rejected by timeout
+          return;
+        }
+        reject(reason);
+      });
+  });
+}
+
+function limitContext<T>(p: Promise<T>, ctx: IContext): Promise<T> {
+  if (ctx == null || ctx.canceler == null) {
+    return p;
+  }
+
+  const clr = ctx.canceler;
+  if (clr.canceled) {
+    return Promise.reject(timeoutError());
+  }
+
+  let rejected = false;
+
+  const handler: {
+    cancel?: CancelFunc;
+    reject?: FnReject;
+  } = {};
+
+  handler.cancel = () => {
+    clr.off(handler.cancel!);
+    rejected = true;
+    handler.reject!(timeoutError());
+  };
+
+  clr.onCancel(handler.cancel);
+
+  return new Promise<T>((resolve, reject) => {
+    handler.reject = reject;
+    p.finally(() => {
+      clr.off(handler.cancel!);
+    })
+      .then((value) => {
+        if (rejected) {
+          // Already rejected by timeout
+          return;
+        }
+        resolve(value);
+      })
+      .catch((reason) => {
+        if (rejected) {
+          // Already rejected by timeout
+          return;
+        }
+        reject(reason);
+      });
+  });
+}

--- a/test/limit.spec.ts
+++ b/test/limit.spec.ts
@@ -1,0 +1,193 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+import { later, limit } from '$';
+import { Context, IContext } from '@sabl/context';
+
+describe('limit', () => {
+  describe('resolve', () => {
+    it('resolves with ms', async () => {
+      const p = later(22, 2);
+      const result = await limit(p, 4);
+      expect(result).toBe(22);
+    });
+
+    it('resolves with deadline', async () => {
+      const p = later(22, 2);
+      const result = await limit(p, new Date(4 + +new Date()));
+      expect(result).toBe(22);
+    });
+
+    it('resolves with null context', async () => {
+      const p = later(22, 2);
+      const result = await limit(p, <IContext>null!);
+      expect(result).toBe(22);
+    });
+
+    it('resolves with non-cancelable context', async () => {
+      const p = later(22, 2);
+      const result = await limit(p, Context.background);
+      expect(result).toBe(22);
+    });
+
+    it('resolves with cancelable context', async () => {
+      const [ctx, cancel] = Context.cancel();
+      const p = later(22, 2);
+      const result = await limit(p, ctx);
+      expect(result).toBe(22);
+      cancel();
+    });
+  });
+
+  describe('reject', () => {
+    it('rejects with ms', async () => {
+      const p = Promise.reject(new Error('failing on purpose'));
+      const pLimit = limit(p, 4);
+      await expect(pLimit).rejects.toThrow('failing on purpose');
+    });
+
+    it('rejects with deadline', async () => {
+      const p = Promise.reject(new Error('failing on purpose'));
+      const pLimit = limit(p, new Date(4 + +new Date()));
+      await expect(pLimit).rejects.toThrow('failing on purpose');
+    });
+
+    it('rejects with null context', async () => {
+      const p = Promise.reject(new Error('failing on purpose'));
+      const pLimit = limit(p, <IContext>null!);
+      await expect(pLimit).rejects.toThrow('failing on purpose');
+    });
+
+    it('rejects with non-cancelable context', async () => {
+      const p = Promise.reject(new Error('failing on purpose'));
+      const pLimit = limit(p, Context.background);
+      await expect(pLimit).rejects.toThrow('failing on purpose');
+    });
+
+    it('rejects with cancelable context', async () => {
+      const [ctx, cancel] = Context.cancel();
+      const p = Promise.reject(new Error('failing on purpose'));
+      const pLimit = limit(p, ctx);
+      await expect(pLimit).rejects.toThrow('failing on purpose');
+      cancel();
+    });
+  });
+
+  describe('timeout', () => {
+    it('times out before resolve with ms', async () => {
+      const p = later(22, 10);
+      const pLimit = limit(p, 1);
+
+      // Outer promise rejects with cancellation error
+      await expect(pLimit).rejects.toThrow('canceled due to timeout');
+
+      // Inner promise still resolves as expected
+      expect(await p).toBe(22);
+    });
+
+    it('times out before resolve with deadline', async () => {
+      const p = later(22, 10);
+      const pLimit = limit(p, new Date(1 + +new Date()));
+
+      // Outer promise rejects with cancellation error
+      await expect(pLimit).rejects.toThrow('canceled due to timeout');
+
+      // Inner promise still resolves as expected
+      expect(await p).toBe(22);
+    });
+
+    it('times out before resolve with cancelable context', async () => {
+      const [ctx, cancel] = Context.cancel();
+      const p = later(22, 10);
+      const pLimit = limit(p, ctx);
+      setTimeout(cancel, 1);
+
+      // Outer promise rejects with cancellation error
+      await expect(pLimit).rejects.toThrow('canceled due to timeout');
+
+      // Inner promise still resolves as expected
+      expect(await p).toBe(22);
+    });
+
+    it('immediately times out with 0 ms', async () => {
+      const p = Promise.resolve(22);
+      const pLimit = limit(p, 0);
+
+      // Outer promise rejects with cancellation error
+      await expect(pLimit).rejects.toThrow('canceled due to timeout');
+
+      // Inner promise still resolves as expected
+      expect(await p).toBe(22);
+    });
+
+    it('immediately times out with past deadline', async () => {
+      const p = Promise.resolve(22);
+      const pLimit = limit(p, new Date(+new Date() - 1000));
+
+      // Outer promise rejects with cancellation error
+      await expect(pLimit).rejects.toThrow('canceled due to timeout');
+
+      // Inner promise still resolves as expected
+      expect(await p).toBe(22);
+    });
+
+    it('immediately times out with canceled context', async () => {
+      const [ctx, cancel] = Context.cancel();
+      cancel();
+
+      const p = Promise.resolve(22);
+      const pLimit = limit(p, ctx);
+
+      // Outer promise rejects with cancellation error
+      await expect(pLimit).rejects.toThrow('canceled due to timeout');
+
+      // Inner promise still resolves as expected
+      expect(await p).toBe(22);
+    });
+
+    it('times out before reject with ms', async () => {
+      const p = later(() => {
+        throw new Error('failing on purpose');
+      }, 10);
+
+      const pLimit = limit(p, 1);
+
+      // Outer promise rejects with cancellation error
+      await expect(pLimit).rejects.toThrow('canceled due to timeout');
+
+      // Inner promise still rejects as expected
+      await expect(p).rejects.toThrow('on purpose');
+    });
+
+    it('times out before reject with deadline', async () => {
+      const p = later(() => {
+        throw new Error('failing on purpose');
+      }, 10);
+
+      const pLimit = limit(p, new Date(1 + +new Date()));
+
+      // Outer promise rejects with cancellation error
+      await expect(pLimit).rejects.toThrow('canceled due to timeout');
+
+      // Inner promise still rejects as expected
+      await expect(p).rejects.toThrow('on purpose');
+    });
+
+    it('times out before reject with cancelable context', async () => {
+      const [ctx, cancel] = Context.cancel();
+      const p = later(() => {
+        throw new Error('failing on purpose');
+      }, 10);
+
+      const pLimit = limit(p, ctx);
+      setTimeout(cancel, 1);
+
+      // Outer promise rejects with cancellation error
+      await expect(pLimit).rejects.toThrow('canceled due to timeout');
+
+      // Inner promise still rejects as expected
+      await expect(p).rejects.toThrow('on purpose');
+    });
+  });
+});


### PR DESCRIPTION
Implements `limit` to automatically reject promises based on timeout or cancelable context.