### PR TITLE
refactor: remove is-canceled

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,12 @@ class AsyncQueue<T> {
 ### Cancelable `promise`
 
 ```ts
-function promise<T>(ctx: IContext): CallbackPromise<T>;
-
-function isCanceled(reason: unknown): boolean;
+function promise<T>(ctx: IContext): CallbackPromise<T>; 
 ```
 
-`promise` also supports an overload which accepts a [context](https://). If the context is cancelable, and the context is canceled before the promise is resolved, then the promise is automatically rejected with a cancellation error.
+`promise` also supports an overload which accepts a [context](https://github.com/libsabl/context-js). If the context is cancelable, and the context is canceled before the promise is resolved, then the promise is automatically rejected with a cancellation error.
 
-The helper function `isCanceled` checks a rejection reason or error value to detect if the error represents an automatic cancellation.
+The helper function `CanceledError.is` from [`@sabl/context`](https://npmjs.org/package/@sabl/context) checks a rejection reason or error value to detect if the error represents an automatic cancellation.
 
 #### **Example revisited**: Async queue with cancelable get:
 
@@ -95,7 +93,7 @@ class AsyncQueue<T> {
     this.#reqQueue.push(p);
 
     const wrapped = p.catch((reason) => {
-      if(isCanceled(reason)) {
+      if(CanceledError.is(reason)) {
         // Request was canceled. Remove from queue
         this.#reqQueue.splice(this.#reqQueue.indexOf(p));
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sabl/async",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Basic utilities for asynchronous programming",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -30,7 +30,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@sabl/context": "^1.0.0"
+    "@sabl/context": "^1.1.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,7 @@ lockfileVersion: 5.3
 specifiers:
   '@commitlint/cli': ^16.3.0
   '@commitlint/config-conventional': ^16.2.4
-  '@sabl/context': ^1.0.0
+  '@sabl/context': ^1.1.1
   '@types/jest': ^28.1.6
   '@types/node': ^17.0.45
   '@types/rmfr': ^2.0.1
@@ -25,7 +25,7 @@ specifiers:
   typescript: ^4.7.4
 
 dependencies:
-  '@sabl/context': 1.0.0
+  '@sabl/context': 1.1.1
 
 devDependencies:
   '@commitlint/cli': 16.3.0
@@ -734,7 +734,7 @@ packages:
     resolution: {integrity: sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@sinclair/typebox': 0.24.21
+      '@sinclair/typebox': 0.24.22
     dev: true
 
   /@jest/source-map/28.1.2:
@@ -867,12 +867,12 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@sabl/context/1.0.0:
-    resolution: {integrity: sha512-eGU3jk0UXUwzAfs99QhssOBmhhNKKTXsudaFNGMKSODg5wIp9Aj91gG1lfboTOTxdx5gFwJ5RVf2kU4G57dCgw==}
+  /@sabl/context/1.1.1:
+    resolution: {integrity: sha512-CEDOCD+JP/z26Hd9nzfuKR1Jni/eERFhoHut0es6b6NKQCqnLq0/+nNdcBoutjhRGdD8KHaGX1I0PZ9QXa2hsg==}
     dev: false
 
-  /@sinclair/typebox/0.24.21:
-    resolution: {integrity: sha512-II2SIjvxBVJmrGkkZYza/BqNjwx3PWROIA8CZ0/Hn7LV0Mv0CVpZxoyHGBVsQqfFLMv9DmArIeRHTwo76bE6oA==}
+  /@sinclair/typebox/0.24.22:
+    resolution: {integrity: sha512-JsBe3cOFpNZ6yjBYnXKhcENWy5qZE3PQZwExQ5ksA/h8qp4bwwxFmy07A6bC2R6qv6+RF3SfrbQTskTwYNTXUQ==}
     dev: true
 
   /@sinonjs/commons/1.8.3:
@@ -1369,7 +1369,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001373
-      electron-to-chromium: 1.4.204
+      electron-to-chromium: 1.4.206
       node-releases: 2.0.6
       update-browserslist-db: 1.0.5_browserslist@4.21.3
     dev: true
@@ -1653,8 +1653,8 @@ packages:
       is-obj: 2.0.0
     dev: true
 
-  /electron-to-chromium/1.4.204:
-    resolution: {integrity: sha512-5Ojjtw9/c9HCXtMVE6SXVSHSNjmbFOXpKprl6mY/5moLSxLeWatuYA7KTD+RzJMxLRH6yNNQrqGz9p6IoNBMgw==}
+  /electron-to-chromium/1.4.206:
+    resolution: {integrity: sha512-h+Fadt1gIaQ06JaIiyqPsBjJ08fV5Q7md+V8bUvQW/9OvXfL2LRICTz2EcnnCP7QzrFTS6/27MRV6Bl9Yn97zA==}
     dev: true
 
   /emittery/0.10.2:

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 
 import { EventEmitter } from 'events';
-import { IContext } from '@sabl/context';
-import { promise, CallbackPromise, isCanceled } from './promise';
+import { CanceledError, IContext } from '@sabl/context';
+import { promise, CallbackPromise } from './promise';
 
 export interface AsyncFactory<T extends object> {
   /** Create a new item */
@@ -382,11 +382,11 @@ class Pool<T extends object>
 
     // Enqueue the request
     const queue = this.#queue;
-    const handle = promise<T>(ctx!, this.#err.canceled);
+    const handle = promise<T>(ctx!);
     queue.push(handle);
 
     const wrapped = handle.catch((reason) => {
-      if (isCanceled(reason)) {
+      if (CanceledError.is(reason)) {
         // If the request was canceled,
         // remove the request from the queue
         queue.splice(queue.indexOf(handle), 1);

--- a/test/pool.spec.ts
+++ b/test/pool.spec.ts
@@ -173,9 +173,7 @@ describe('get', () => {
     // Cancel in 5 ms
     setTimeout(cancel, 5);
 
-    await expect(pItem2).rejects.toThrow(
-      'canceled before an item was available'
-    );
+    await expect(pItem2).rejects.toThrow('canceled');
 
     // Should no longer be any waiting requests
     expect(pool.stats().waitCount).toBe(0);


### PR DESCRIPTION
Removes isCanceled helper function to rely instead on cancellation-checking logic in @sabl/context.